### PR TITLE
fix: vendor dart sdk

### DIFF
--- a/mason.rb
+++ b/mason.rb
@@ -43,7 +43,7 @@ class Mason < Formula
     # Change directories into the mason_cli package directory.
     Dir.chdir('packages/mason_cli')
 
-    system dart/"dart", "pub", "get"
+    system dart, "pub", "get"
   
     if Hardware::CPU.is_64_bit?
       _install_native_executable(dart)

--- a/mason.rb
+++ b/mason.rb
@@ -7,30 +7,63 @@ class Mason < Formula
   sha256 "a21a2de3bb340d9811d5fe32608a031a65dcd0499b4b9688784a275a48d471ba"
   license "MIT"
 
-  depends_on "dart-lang/dart/dart" => :build
+  # Determine architecture and set the Dart SDK resource accordingly
+  dart_sdk_version = "3.6.0"
+  dart_sdk_url, dart_sdk_sha = if OS.mac? && Hardware::CPU.intel?
+    ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-macos-x64-release.zip",
+     "b859b1abd92997b389061be6b301e598a3edcbf7e092cfe5b8d6ce2acdf0732b"]
+  elsif OS.mac? && Hardware::CPU.arm?
+    ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-macos-arm64-release.zip",
+     "1bdbc6544aaa53673e7cbbf66ad7cde914cb7598936ebbd6a4245e1945a702a0"]
+  elsif OS.linux? && Hardware::CPU.intel?
+    ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-linux-x64-release.zip",
+     "8e14ff436e1eec72618dabc94f421a97251f2068c9cc9ad2d3bb9d232d6155a3"]
+  elsif OS.linux? && Hardware::CPU.arm?
+    ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-linux-arm64-release.zip",
+     "0f82f10f808c7003d0d03294ae9220b5e0824ab3d2d19b4929d4fa735254e7bf"]
+  end
+
+  resource "dart-sdk" do
+    url dart_sdk_url
+    sha256 dart_sdk_sha
+  end
 
   def install
+    # Resource installation for Dart SDK
+    resource("dart-sdk").stage do
+      libexec.install Dir["*"] # Assumes Dart SDK zip layout matches what's expected
+    end
+    
     # Tell the pub server where these installations are coming from.
     ENV["PUB_ENVIRONMENT"] = "homebrew:mason_cli"
+
+    # Adjust paths to use the vendored Dart SDK
+    dart = libexec/"bin/dart"
 
     # Change directories into the mason_cli package directory.
     Dir.chdir('packages/mason_cli')
 
-    system _dart/"dart", "pub", "get"
+    system dart/"dart", "pub", "get"
   
-    _install_script_snapshot
+    if Hardware::CPU.is_64_bit?
+      _install_native_executable(dart)
+    else
+      _install_script_snapshot(dart)
+    end
 
     chmod 0555, "#{bin}/mason"
   end
 
   private
 
-  def _dart
-    @_dart ||= Formula["dart-lang/dart/dart"].libexec/"bin"
-  end
-
   def _version
     @_version ||= YAML.safe_load(File.read("pubspec.yaml"))["version"]
+  end
+
+  def _install_native_executable(dart)
+    system dart, "compile", "exe", "-Dversion=#{_version}",
+           "bin/main.dart", "-o", "fvm"
+    bin.install "fvm"
   end
 
   def _install_script_snapshot
@@ -40,7 +73,7 @@ class Mason < Formula
            "bin/mason.dart"
     lib.install "mason.dart.app.snapshot"
     
-    cp _dart/"dart", lib
+    cp dart, lib
 
     (bin/"mason").write <<~SH
       #!/bin/sh

--- a/mason.rb
+++ b/mason.rb
@@ -62,8 +62,8 @@ class Mason < Formula
 
   def _install_native_executable(dart)
     system dart, "compile", "exe", "-Dversion=#{_version}",
-           "bin/main.dart", "-o", "fvm"
-    bin.install "fvm"
+           "bin/mason.dart", "-o", "mason"
+    bin.install "mason"
   end
 
   def _install_script_snapshot

--- a/mason.rb
+++ b/mason.rb
@@ -8,19 +8,19 @@ class Mason < Formula
   license "MIT"
 
   # Determine architecture and set the Dart SDK resource accordingly
-  dart_sdk_version = "3.6.0"
+  dart_sdk_version = "3.7.0"
   dart_sdk_url, dart_sdk_sha = if OS.mac? && Hardware::CPU.intel?
     ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-macos-x64-release.zip",
-     "b859b1abd92997b389061be6b301e598a3edcbf7e092cfe5b8d6ce2acdf0732b"]
+     "d601c9da420552dc6deba1992d07aad9637b970077d58c5cda895baebc83d7f5"]
   elsif OS.mac? && Hardware::CPU.arm?
     ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-macos-arm64-release.zip",
-     "1bdbc6544aaa53673e7cbbf66ad7cde914cb7598936ebbd6a4245e1945a702a0"]
+     "9bfd7c74ebc5f30b5832dfcf4f47e5a3260f2e9b98743506c67ad02b3b6964bb"]
   elsif OS.linux? && Hardware::CPU.intel?
     ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-linux-x64-release.zip",
-     "8e14ff436e1eec72618dabc94f421a97251f2068c9cc9ad2d3bb9d232d6155a3"]
+     "7c849abc0d06a130d26d71490d5f2b4b2fe1ca477b1a9cee6b6d870e6f9d626f"]
   elsif OS.linux? && Hardware::CPU.arm?
     ["https://storage.googleapis.com/dart-archive/channels/stable/release/#{dart_sdk_version}/sdk/dartsdk-linux-arm64-release.zip",
-     "0f82f10f808c7003d0d03294ae9220b5e0824ab3d2d19b4929d4fa735254e7bf"]
+     "367b5a6f1364a1697dc597775e5cd7333c332363902683a0970158cbb978b80d"]
   end
 
   resource "dart-sdk" do


### PR DESCRIPTION
When using fvm to manage versions and setting a global one with `fvm global` and adding the global version to path, it seems that the dart-sdk dependency from the mason formula installs the dart sdk in the global path, therefore it creates conflicts when running meson (Invalid SDK hash errors) which casuses problems with autocomplete too.

This PR fixes this problem and also installs meson as a native exectuable on 64bit systems.

I took the solution directly from the FVM app which, instead of using the dart-sdk from homebrew use a venderored sdk version when building it which is kept separated from the others.

